### PR TITLE
Fix always-true condition in ballow() type checks

### DIFF
--- a/odchsrc/src/commands.c
+++ b/odchsrc/src/commands.c
@@ -2488,7 +2488,7 @@ int ballow(char *buf, int type, struct user_t *user)
      return -1;
    
    now_time = time(NULL);
-   if(type == NICKBAN || GAG)
+   if(type == NICKBAN || type == GAG)
      {
 	if(sscanf(buf, "%50s %lu%c", ban_host, &ban_time, &period) == 1)
 	  ban_host[strlen(ban_host) - 1] = '\0';
@@ -2615,7 +2615,7 @@ int ballow(char *buf, int type, struct user_t *user)
 	return -1;
      }	
    
-   if(type == NICKBAN || GAG)
+   if(type == NICKBAN || type == GAG)
      {
      if(type == GAG)
      {


### PR DESCRIPTION
## Summary
- Fix `if(type == NICKBAN || GAG)` to `if(type == NICKBAN || type == GAG)` at two locations in `ballow()`
- `GAG` is defined as constant `6`, so `|| GAG` is always true regardless of `type`
- This caused BAN and ALLOW operations to incorrectly use the NICKBAN code path, truncating hostnames to 50 chars and applying wrong permission checks

## Test plan
- [ ] IP bans now use correct `%120s` format and full host length
- [ ] Nick bans still work correctly
- [ ] Gag operations still work correctly
- [ ] Allow operations unaffected by NICKBAN logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)