### PR TITLE
Migrate CI from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y perl libperl-dev autoconf automake build-essential
+
+      - name: Build
+        working-directory: odchsrc
+        run: |
+          automake --add-missing --copy 2>/dev/null || true
+          autoreconf -fi 2>/dev/null || autoconf -f
+          CFLAGS="-fcommon" ./configure
+          make
+
+      - name: Verify binary
+        run: test -x odchsrc/src/opendchub
+
+  integration:
+    runs-on: ubuntu-latest
+    name: Integration tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker test image
+        run: docker build -f Dockerfile.test -t odch-test .
+
+      - name: Run integration tests
+        run: docker run --rm odch-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           path: odchbot
 
       - name: Build Docker test image
-        run: docker build -f Dockerfile.test -t odch-test .
+        run: docker build --no-cache -f Dockerfile.test -t odch-test .
 
       - name: Run integration tests
         run: docker run --rm odch-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout odchbot
+        uses: actions/checkout@v4
+        with:
+          repository: typhonius/odchbot
+          ref: v3
+          path: odchbot
+
       - name: Build Docker test image
         run: docker build -f Dockerfile.test -t odch-test .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: c
-install: sudo apt-get update > /dev/null
-before_script:
- - sudo apt-get install perl libperl-dev
- - tar zxf opendchub.tar.gz
- - cd opendchub
-script:
- - "./configure && make && make check"

--- a/test_gag.sh
+++ b/test_gag.sh
@@ -241,6 +241,7 @@ cp /build/odchbot/DCBDatabase.pm /root/.opendchub/scripts/
 cp /build/odchbot/DCBCommon.pm /root/.opendchub/scripts/
 cp /build/odchbot/DCBUser.pm /root/.opendchub/scripts/
 cp /build/odchbot/odchbot.yml /root/.opendchub/scripts/odchbot.yml
+chmod 600 /root/.opendchub/scripts/odchbot.yml
 cp /build/odchbot/odchbot.log4perl.conf /root/.opendchub/scripts/
 cp -r /build/odchbot/commands /root/.opendchub/scripts/commands
 mkdir -p /root/.opendchub/scripts/logs


### PR DESCRIPTION
## Summary
- Replace deprecated Travis CI with GitHub Actions
- Build job: Ubuntu, autotools build with Perl/libperl-dev support
- Integration test job: builds Docker image from `Dockerfile.test`, runs full 62-test suite
- Delete `.travis.yml`

## Test plan
- [ ] Verify build job compiles opendchub binary successfully
- [ ] Verify integration test job passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)