### PR TITLE
Fix Perl 5.38 build compatibility in xs_functions.c

### DIFF
--- a/odchsrc/src/xs_functions.c
+++ b/odchsrc/src/xs_functions.c
@@ -38,7 +38,7 @@
 
 #define EXTERN_C extern
 
-EXTERN_C void boot_DynaLoader (CV* cv);
+EXTERN_C void boot_DynaLoader (pTHX_ CV* cv);
 static char *user_list = NULL;
 static char *description = NULL;
 static char *email = NULL;
@@ -276,8 +276,11 @@ XS(xs_check_if_banned)
    ret = check_if_banned(user, BAN);
    if(ret != 1)
      ret = check_if_banned(user, NICKBAN);
-   
-   (ret == 1) ? XSRETURN_IV(1) : XSRETURN_IV(0);
+
+   if(ret == 1)
+     XSRETURN_IV(1);
+   else
+     XSRETURN_IV(0);
 }
 
 XS(xs_check_if_allowed)
@@ -296,8 +299,11 @@ XS(xs_check_if_allowed)
      XSRETURN_UNDEF;
    
    ret = check_if_allowed(user);
-   
-   (ret == 1) ? XSRETURN_IV(1) : XSRETURN_IV(0);
+
+   if(ret == 1)
+     XSRETURN_IV(1);
+   else
+     XSRETURN_IV(0);
 }
 
 XS(xs_data_to_user)


### PR DESCRIPTION
## Summary
- Replace `XSRETURN_IV` in ternary expressions with `if/else` — the macro expands to `do{...}while(0)` which is a statement, not an expression
- Update `boot_DynaLoader` prototype to use `pTHX_ CV*` for modern Perl's `XSUBADDR_t` calling convention

These patterns compiled on Perl 5.14–5.34 but fail on 5.38 (Ubuntu 24.04's default).

## Test plan
- [ ] Verify `make` succeeds on Ubuntu latest (Perl 5.38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)