### PR TITLE
Add release workflow to build .deb on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y perl libperl-dev autoconf automake build-essential
+          sudo apt-get install -y perl libperl-dev libssl-dev libcrypt-dev autoconf automake build-essential
 
       - name: Build
         run: |
           automake --add-missing --copy 2>/dev/null || true
           autoreconf -fi 2>/dev/null || autoconf -f
-          ./configure
+          ./configure --enable-ssl
           make
 
       - name: Verify binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-deb:
+    runs-on: ubuntu-24.04
+    name: Build .deb package
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf automake \
+            perl libperl-dev libcrypt-dev libssl-dev checkinstall
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        run: |
+          automake --add-missing --copy 2>/dev/null || true
+          autoreconf -fi 2>/dev/null || autoconf -f
+          ./configure --enable-ssl
+          make
+
+      - name: Verify binary
+        run: |
+          test -x src/opendchub
+          src/opendchub --help 2>&1 || true
+
+      - name: Create .deb package
+        run: |
+          sudo checkinstall --install=no --default \
+            --pkgname=opendchub \
+            --pkgversion=${{ steps.version.outputs.version }} \
+            --pkgrelease=1 \
+            --pkglicense=GPL-2 \
+            --pkggroup=net \
+            --maintainer="typhonius@users.noreply.github.com" \
+            --requires="libssl3,libperl5.38,libcrypt1" \
+            --nodoc \
+            make install
+
+      - name: Rename package
+        run: |
+          mv opendchub_*.deb opendchub_${{ steps.version.outputs.version }}_amd64.deb
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: opendchub_${{ steps.version.outputs.version }}_amd64.deb
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- New `release.yml` workflow: builds `.deb` via checkinstall on Ubuntu 24.04, uploads as GitHub release asset on tag push (`v*`)
- Updates `ci.yml`: adds `libssl-dev` and `--enable-ssl` so SSL code paths are compiled and tested in CI

## Usage
```bash
git tag v0.8.3
git push origin v0.8.3
```
Then download `opendchub_0.8.3_amd64.deb` from the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)