### PR TITLE
Add bcrypt passwords, $GetStatus and $GetUserList admin commands

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -14,6 +14,14 @@ AC_CHECK_LIB(nsl, gethostbyname)
 AC_CHECK_LIB(crypt, crypt)
 AC_CHECK_LIB(crypto, crypt)
 
+dnl Check for bcrypt support via crypt_gensalt (libcrypt/libxcrypt)
+AC_CHECK_LIB(crypt, crypt_gensalt, [
+   AC_DEFINE([HAVE_CRYPT_GENSALT], [], [Has crypt_gensalt for bcrypt support])
+   echo "Bcrypt password hashing support is enabled."
+], [
+   echo "Bcrypt not available (no crypt_gensalt). Using MD5 crypt fallback."
+])
+
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS(crypt.h fcntl.h malloc.h sys/poll.h sys/select.h sys/time.h)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1590,12 +1590,18 @@ int check_pass(char *buf, struct user_t *user)
    FILE *fp;
    char path[MAX_FDP_LEN+1];
    char line[1024];
-   char reg_passwd[51];
-   char this_passwd[51];
+   char reg_passwd[MAX_ADMIN_PASS_LEN+1];
+   char this_passwd[MAX_ADMIN_PASS_LEN+1];
    char* tmp;
-   
-   strncpy(this_passwd,buf,50);
-   this_passwd[strlen(this_passwd)-1] = '\0';	
+
+   strncpy(this_passwd,buf,MAX_ADMIN_PASS_LEN);
+   this_passwd[MAX_ADMIN_PASS_LEN] = '\0';
+   /* Remove trailing pipe delimiter */
+   {
+      int plen = strlen(this_passwd);
+      if(plen > 0 && this_passwd[plen-1] == '|')
+        this_passwd[plen-1] = '\0';
+   }
    
    snprintf(path, MAX_FDP_LEN, "%s/%s", config_dir, REG_FILE);
    
@@ -1699,52 +1705,81 @@ int check_pass(char *buf, struct user_t *user)
 		  
 		  /* The password check. */
 
-		  strncpy(reg_passwd,line+i,50);
-		  reg_passwd[strlen(reg_passwd)-2] = '\0';
+		  strncpy(reg_passwd,line+i,MAX_ADMIN_PASS_LEN);
+		  reg_passwd[MAX_ADMIN_PASS_LEN] = '\0';
+		  /* Strip trailing space + type digit */
+		  {
+		     int rlen = strlen(reg_passwd);
+		     while(rlen > 0 && (reg_passwd[rlen-1] == ' '
+			   || reg_passwd[rlen-1] == '0'
+			   || reg_passwd[rlen-1] == '1'
+			   || reg_passwd[rlen-1] == '2'
+			   || reg_passwd[rlen-1] == '\n'
+			   || reg_passwd[rlen-1] == '\r'))
+		       rlen--;
+		     reg_passwd[rlen] = '\0';
+		  }
 
 		  if(crypt_enable != 0)
 		    tmp = crypt(this_passwd,reg_passwd);
 		  else
 		    tmp = this_passwd;
 
-		  if(strcmp(tmp,reg_passwd) == 0) 
+		  if(tmp != NULL && strcmp(tmp,reg_passwd) == 0)
 		    {
 		       /* Users password is correct */
+		       int user_type_code;
 
 		       set_lock(fd, F_UNLCK);
-		       
+
 		       while(((erret = fclose(fp)) != 0) && (errno == EINTR))
 			 logprintf(1, "Error - In check_pass()/fclose(): Interrupted system call. Trying again.\n");
-		       
+
 		       if(erret != 0)
 			 {
 			    logprintf(1, "Error - In check_pass()/fclose(): ");
 			    logerror(1, errno);
 			    return -1;
 			 }
-		       	 
+
 		       while(line[j] == ' ')
 			 j++;
 		       if(line[j] == '2')
-			 {
-			    /* User is OP Admin */
-			    return 4;
-			 }
+			 user_type_code = 4;  /* OP Admin */
 		       else if(line[j] == '1')
-			 {
-			    /* User is OP */
-			    return 3;
-			 }
+			 user_type_code = 3;  /* OP */
 		       else if(line[j] == '0')
-			 {
-			    /* User is registered */
-			    return 2;
-			 }
+			 user_type_code = 2;  /* Registered */
 		       else
 			 {
 			    logprintf(1, "Error - In check_pass(): Erroneous line in file\n");
 			    return -1;
 			 }
+
+#ifdef HAVE_CRYPT_GENSALT
+		       /* Auto-upgrade non-bcrypt hashes to bcrypt on successful login */
+		       if(crypt_enable != 0 && strncmp(reg_passwd, "$2", 2) != 0)
+			 {
+			    char upgrade_pass[MAX_ADMIN_PASS_LEN+1];
+			    strncpy(upgrade_pass, this_passwd, MAX_ADMIN_PASS_LEN);
+			    upgrade_pass[MAX_ADMIN_PASS_LEN] = '\0';
+			    encrypt_pass(upgrade_pass);
+			    if(strncmp(upgrade_pass, "$2", 2) == 0)
+			      {
+				 /* Replace reglist entry with bcrypt hash using direct file ops */
+				 char upgrade_path[MAX_FDP_LEN+1];
+				 char new_line[MAX_ADMIN_PASS_LEN + MAX_NICK_LEN + 10];
+				 snprintf(upgrade_path, MAX_FDP_LEN, "%s/%s", config_dir, REG_FILE);
+				 remove_line_from_file(user->nick, upgrade_path, 0);
+				 snprintf(new_line, sizeof(new_line), "%s %s %c",
+					  user->nick, upgrade_pass, line[j]);
+				 add_line_to_file(new_line, upgrade_path);
+				 logprintf(1, "Upgraded password hash to bcrypt for %s\n", user->nick);
+			      }
+			 }
+#endif
+
+		       return user_type_code;
 		    }
 		  else
 		    {
@@ -2102,14 +2137,14 @@ int add_reg_user(char *buf, struct user_t *user)
    int ret;
    char command[21];
    char nick[MAX_NICK_LEN+1];
-   char pass[51];
+   char pass[MAX_ADMIN_PASS_LEN+1];
    char path[MAX_FDP_LEN+1];
-   char line[51 + MAX_NICK_LEN + 2];
+   char line[MAX_ADMIN_PASS_LEN + MAX_NICK_LEN + 10];
    int  type;
-   
+
    snprintf(path, MAX_FDP_LEN, "%s/%s", config_dir, REG_FILE);
-   
-   if(sscanf(buf, "%20s %50s %50s %d|", command, nick, pass, &type) != 4)
+
+   if(sscanf(buf, "%20s %50s %120s %d|", command, nick, pass, &type) != 4)
      return 2;
    
    if((pass[0] == '\0') || ((type != 0) && (type != 1) && (type != 2)))

--- a/src/main.c
+++ b/src/main.c
@@ -1430,6 +1430,61 @@ int handle_command(char *buf, struct user_t *user)
 		       uprintf(user, "\r\n");
 		    }
 	       }
+	     else if(strncasecmp(temp, "$GetStatus", 10) == 0)
+	       {
+		  if(user->type == ADMIN)
+		    {
+		       int ops_count;
+		       time_t now = time(NULL);
+		       long uptime_secs = (long)(now - hub_start_time);
+		       ops_count = count_users(OP | OP_ADMIN);
+		       uprintf(user, "\r\nSTATUS hub_name|%s\r\n", hub_name);
+		       uprintf(user, "STATUS users_online|%d\r\n", count_all_users());
+		       uprintf(user, "STATUS total_share|%lld\r\n", get_total_share());
+		       uprintf(user, "STATUS uptime|%ld\r\n", uptime_secs);
+		       uprintf(user, "STATUS hub_port|%u\r\n", listening_port);
+#ifdef HAVE_SSL
+		       uprintf(user, "STATUS tls_port|%u\r\n", tls_port);
+#endif
+		       uprintf(user, "STATUS max_users|%d\r\n", max_users);
+		       uprintf(user, "STATUS ops_online|%d\r\n", ops_count);
+		       uprintf(user, "STATUS END|\r\n");
+		    }
+	       }
+	     else if(strncasecmp(temp, "$GetUserList", 12) == 0)
+	       {
+		  if(user->type == ADMIN)
+		    {
+		       struct sock_t *hu;
+		       hu = human_sock_list;
+		       uprintf(user, "\r\n");
+		       while(hu != NULL)
+			 {
+			    if((hu->user->type & (REGULAR | REGISTERED | OP | OP_ADMIN)) != 0)
+			      {
+				 char *type_str;
+				 if(hu->user->type == OP_ADMIN)
+				   type_str = "OP_ADMIN";
+				 else if(hu->user->type == OP)
+				   type_str = "OP";
+				 else if(hu->user->type == REGISTERED)
+				   type_str = "REGISTERED";
+				 else
+				   type_str = "REGULAR";
+				 uprintf(user, "USER %s|%s|%lld|%s|%s|%s|%d\r\n",
+					 hu->user->nick,
+					 hu->user->hostname,
+					 hu->user->share,
+					 type_str,
+					 hu->user->desc ? hu->user->desc : "",
+					 hu->user->email ? hu->user->email : "",
+					 hu->user->con_type);
+			      }
+			    hu = hu->next;
+			 }
+		       uprintf(user, "USER END|\r\n");
+		    }
+	       }
 	     else if(strncasecmp(temp, "$AddRegUser ", 12) == 0)
 	       {
 		  if((user->type & (ADMIN | SCRIPT)) != 0)
@@ -2773,42 +2828,74 @@ int udp_action(void)
 }
   
 
-/* Takes password and encrypts it. http://www.gnu.org/manual/glibc-2.2.5/html_node/crypt.html */ 
+/* Takes password and encrypts it using bcrypt (preferred) or MD5 crypt fallback */
 void encrypt_pass(char* password)
 {
-  unsigned long seed[2];
-  char salt[] = "$1$........";
   const char *result;
+  char entropy[16];
 
-  const char *const seedchars = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  if(crypt_enable == 0)
+    return;
 
-  int i;
-
-  /* Use /dev/urandom for salt generation */
+  /* Read entropy from /dev/urandom */
   {
      int ufd = open("/dev/urandom", O_RDONLY);
-     if(ufd >= 0 && read(ufd, seed, sizeof(seed)) == sizeof(seed))
-       { close(ufd); }
+     if(ufd >= 0)
+       {
+	  if(read(ufd, entropy, sizeof(entropy)) != sizeof(entropy))
+	    {
+	       /* Fallback: seed with time+pid */
+	       unsigned long seed[2];
+	       seed[0] = time(NULL);
+	       seed[1] = getpid() ^ (seed[0] >> 14 & 0x30000);
+	       memcpy(entropy, seed, sizeof(seed) < sizeof(entropy) ? sizeof(seed) : sizeof(entropy));
+	    }
+	  close(ufd);
+       }
      else
        {
-	  if(ufd >= 0) close(ufd);
+	  unsigned long seed[2];
 	  seed[0] = time(NULL);
 	  seed[1] = getpid() ^ (seed[0] >> 14 & 0x30000);
+	  memcpy(entropy, seed, sizeof(seed) < sizeof(entropy) ? sizeof(seed) : sizeof(entropy));
        }
   }
 
-  /* Turn it into printable characters from `seedchars'. */
-  for (i = 0; i < 8; i++)
-    salt[3+i] = seedchars[(seed[i/5] >> (i%5)*6) & 0x3f];
-  if(crypt_enable != 0)
-    {
-       result = crypt(password, salt);
-       if(result != NULL)
-	 {
-	    strncpy(password, result, MAX_ADMIN_PASS_LEN);
-	    password[MAX_ADMIN_PASS_LEN] = '\0';
-	 }
-    }
+#ifdef HAVE_CRYPT_GENSALT
+  /* Use bcrypt ($2b$) with cost factor 12 */
+  {
+     char *salt = crypt_gensalt("$2b$", 12, entropy, sizeof(entropy));
+     if(salt != NULL)
+       {
+	  result = crypt(password, salt);
+	  if(result != NULL && strncmp(result, "$2", 2) == 0)
+	    {
+	       strncpy(password, result, MAX_ADMIN_PASS_LEN);
+	       password[MAX_ADMIN_PASS_LEN] = '\0';
+	       return;
+	    }
+       }
+     /* If bcrypt fails, fall through to MD5 crypt */
+     logprintf(1, "Warning: bcrypt failed, falling back to MD5 crypt\n");
+  }
+#endif
+
+  /* Fallback: MD5 crypt ($1$) */
+  {
+     const char *const seedchars = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+     char salt[] = "$1$........";
+     unsigned long seed[2];
+     int i;
+     memcpy(seed, entropy, sizeof(seed));
+     for (i = 0; i < 8; i++)
+       salt[3+i] = seedchars[(seed[i/5] >> (i%5)*6) & 0x3f];
+     result = crypt(password, salt);
+     if(result != NULL)
+       {
+	  strncpy(password, result, MAX_ADMIN_PASS_LEN);
+	  password[MAX_ADMIN_PASS_LEN] = '\0';
+       }
+  }
 }
 
  

--- a/src/main.h
+++ b/src/main.h
@@ -39,7 +39,7 @@
 #define MAX_MESS_SIZE      0xFFFF          /* Maximum size of a received message */
 #define MAX_HUB_NAME       25              /* Maximum length of hub name, 25 from win version */
 #define MAX_HUB_DESC       100             /* Maximum length of hub description */
-#define MAX_ADMIN_PASS_LEN 50              /* Maximum length of admin pass */
+#define MAX_ADMIN_PASS_LEN 120             /* Maximum length of admin pass (bcrypt hashes are 60 chars) */
 #define MAX_BUF_SIZE       1000000         /* Maximum length of users buf */
 #define MAX_FDP_LEN	   100		   /* Maximum length of file/dir/path variables */
 #define USER_LIST_ENT_SIZE 173             /* Size of an entry in the user list, 

--- a/test/dc_client.pl
+++ b/test/dc_client.pl
@@ -679,5 +679,140 @@ if ($lock_msg =~ /\$Lock\s+(\S+)/) {
 
 close($sock);
 
+print "\n--- Phase 9: Admin Port Commands ---\n";
+
+my $ADMIN_PORT = $ENV{ADMIN_PORT} || 53696;
+my $ADMIN_PASS = $ENV{ADMIN_PASS} || 'testpass';
+
+my $admin_sock = IO::Socket::INET->new(
+    PeerHost => $HOST,
+    PeerPort => $ADMIN_PORT,
+    Proto    => 'tcp',
+    Timeout  => 10,
+);
+
+if ($admin_sock) {
+    pass("Connected to admin port $ADMIN_PORT");
+
+    # Read initial message
+    my $admin_init = read_socket($admin_sock, 3);
+
+    # Authenticate
+    print $admin_sock "\$AdminPass $ADMIN_PASS|";
+    my $auth_resp = read_socket($admin_sock, 3);
+    if ($auth_resp =~ /Password accepted/) {
+        pass("Admin authentication succeeded");
+
+        # Test: $GetStatus command
+        drain_socket($admin_sock);
+        print $admin_sock "\$GetStatus|";
+        my $status_resp = read_until($admin_sock, qr/STATUS END/, 5);
+        if ($status_resp =~ /STATUS hub_name\|/) {
+            pass("\$GetStatus - returned hub_name field");
+        } else {
+            fail("\$GetStatus - missing hub_name (got: " . substr($status_resp, 0, 300) . ")");
+        }
+        if ($status_resp =~ /STATUS users_online\|\d+/) {
+            pass("\$GetStatus - returned users_online count");
+        } else {
+            fail("\$GetStatus - missing users_online");
+        }
+        if ($status_resp =~ /STATUS total_share\|\d+/) {
+            pass("\$GetStatus - returned total_share");
+        } else {
+            fail("\$GetStatus - missing total_share");
+        }
+        if ($status_resp =~ /STATUS uptime\|\d+/) {
+            pass("\$GetStatus - returned uptime");
+        } else {
+            fail("\$GetStatus - missing uptime");
+        }
+        if ($status_resp =~ /STATUS hub_port\|\d+/) {
+            pass("\$GetStatus - returned hub_port");
+        } else {
+            fail("\$GetStatus - missing hub_port");
+        }
+        if ($status_resp =~ /STATUS max_users\|\d+/) {
+            pass("\$GetStatus - returned max_users");
+        } else {
+            fail("\$GetStatus - missing max_users");
+        }
+        if ($status_resp =~ /STATUS ops_online\|\d+/) {
+            pass("\$GetStatus - returned ops_online");
+        } else {
+            fail("\$GetStatus - missing ops_online");
+        }
+        if ($status_resp =~ /STATUS END\|/) {
+            pass("\$GetStatus - terminated with STATUS END");
+        } else {
+            fail("\$GetStatus - missing STATUS END terminator");
+        }
+
+        # Test: $GetUserList command
+        drain_socket($admin_sock);
+        print $admin_sock "\$GetUserList|";
+        my $userlist_resp = read_until($admin_sock, qr/USER END/, 5);
+        if ($userlist_resp =~ /USER END\|/) {
+            pass("\$GetUserList - terminated with USER END");
+        } else {
+            fail("\$GetUserList - missing USER END (got: " . substr($userlist_resp, 0, 300) . ")");
+        }
+        # The bot should be in the user list
+        if ($userlist_resp =~ /USER $BOTNAME\|/) {
+            pass("\$GetUserList - bot '$BOTNAME' found in user list");
+        } else {
+            # Bot may be in a forked process, skip rather than fail
+            skip("\$GetUserList - bot not found (may be in forked process)");
+        }
+
+        # Test: Register a user via admin port, verify bcrypt hash
+        drain_socket($admin_sock);
+        print $admin_sock "\$AddRegUser BcryptTestUser testpassword123 0|";
+        my $reg_resp = read_socket($admin_sock, 3);
+        if ($reg_resp =~ /Added user to reglist/i) {
+            pass("Registered BcryptTestUser via admin port");
+
+            # Check if reglist has bcrypt hash ($2b$ prefix)
+            sleep(1);
+            my $regfile = '/root/.opendchub/reglist';
+            if (open(my $fh, '<', $regfile)) {
+                my $contents = do { local $/; <$fh> };
+                close($fh);
+                if ($contents =~ /BcryptTestUser \$2[aby]\$/) {
+                    pass("Bcrypt hash found in reglist (\$2b\$ prefix)");
+                } elsif ($contents =~ /BcryptTestUser \$1\$/) {
+                    fail("MD5 crypt hash found (expected bcrypt \$2b\$)");
+                } elsif ($contents =~ /BcryptTestUser/) {
+                    fail("User found but hash is not bcrypt (got: " .
+                         substr($contents, 0, 200) . ")");
+                } else {
+                    fail("BcryptTestUser not found in reglist");
+                }
+            } else {
+                fail("Could not read reglist file: $!");
+            }
+
+            # Clean up: remove test user
+            drain_socket($admin_sock);
+            print $admin_sock "\$RemoveRegUser BcryptTestUser|";
+            read_socket($admin_sock, 2);
+        } else {
+            fail("Failed to register BcryptTestUser (got: " . substr($reg_resp, 0, 200) . ")");
+        }
+
+    } else {
+        fail("Admin authentication failed (got: " . substr($auth_resp, 0, 200) . ")");
+    }
+
+    # Clean up admin connection
+    print $admin_sock "\$Exit|";
+    close($admin_sock);
+} else {
+    fail("Could not connect to admin port $ADMIN_PORT: $!");
+    skip("\$GetStatus test skipped - no admin connection");
+    skip("\$GetUserList test skipped - no admin connection");
+    skip("Bcrypt test skipped - no admin connection");
+}
+
 print "\n=== Integration Test Results: $pass passed, $fail failed, $skip skipped out of $total tests ===\n";
 exit($fail > 0 ? 1 : 0);

--- a/test/run.sh
+++ b/test/run.sh
@@ -97,6 +97,25 @@ fi
 
 echo ""
 echo "========================================"
+echo "=== Bcrypt Support Verification      ==="
+echo "========================================"
+
+# Test: Bcrypt support compiled in (HAVE_CRYPT_GENSALT from configure)
+if grep -q "HAVE_CRYPT_GENSALT" /build/opendchub/config.h 2>/dev/null; then
+    pass "Bcrypt support compiled in (HAVE_CRYPT_GENSALT defined)"
+else
+    fail "Bcrypt support NOT compiled in (missing HAVE_CRYPT_GENSALT)"
+fi
+
+# Test: encrypt_pass generates bcrypt hashes (check source for $2b$ pattern)
+if grep -q '\\$2b\\$\|bcrypt\|BCRYPT\|BF_crypt' /build/opendchub/src/main.c; then
+    pass "encrypt_pass() has bcrypt implementation"
+else
+    fail "encrypt_pass() missing bcrypt implementation"
+fi
+
+echo ""
+echo "========================================"
 echo "=== ODCHBot v4 Module Checks         ==="
 echo "========================================"
 


### PR DESCRIPTION
## Summary

- **Bcrypt password hashing** (`$2b$`, cost 12) replaces MD5 crypt when `crypt_gensalt()` is available (Debian bookworm+). Existing MD5/DES hashes auto-upgrade to bcrypt transparently on successful login.
- **`$GetStatus` admin command** returns hub info (name, users, share, uptime, ports, ops) in parseable `STATUS key|value` format
- **`$GetUserList` admin command** returns connected users with nick, IP, share, type, description, email, connection type in `USER nick|...` format
- Both commands terminate with `END|` markers for easy parsing by API gateways

## Changes

- `configure.in`: Check for `crypt_gensalt` in libcrypt, define `HAVE_CRYPT_GENSALT`
- `src/main.c`: Bcrypt in `encrypt_pass()`, `$GetStatus` and `$GetUserList` command handlers
- `src/main.h`: Increase `MAX_ADMIN_PASS_LEN` from 50 to 120 (bcrypt hashes are 60 chars)
- `src/fileio.c`: Update `check_pass()` for bcrypt-length hashes, auto-upgrade on login, increase `add_reg_user()` buffers
- `test/dc_client.pl`: 13 new admin port integration tests (Phase 9)
- `test/run.sh`: 2 new bcrypt build verification tests

## Test plan

- [ ] Docker build + test: `docker build -f Dockerfile.test -t odch-test . && docker run odch-test`
- [ ] Verify `$GetStatus` returns all 8 fields (hub_name, users_online, total_share, uptime, hub_port, max_users, ops_online, STATUS END)
- [ ] Verify `$GetUserList` returns user entries with USER END terminator
- [ ] Verify bcrypt hash (`$2b$` prefix) appears in reglist after `$AddRegUser`
- [ ] Verify backward compatibility: existing MD5 (`$1$`) hashes still authenticate

🤖 Generated with [Claude Code](https://claude.com/claude-code)