### PR TITLE
Add systemd service file

### DIFF
--- a/opendchub.service
+++ b/opendchub.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=OpenDCHub Direct Connect Hub
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/usr/local/bin/opendchub
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+User=opendchub
+Group=opendchub
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add `opendchub.service` systemd unit file for running OpenDCHub as a system service
- Supports config hot-reload via `systemctl reload` (sends SIGHUP)
- Auto-restart on failure with 5s delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)