### PR TITLE
Security hardening fixes

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -442,24 +442,25 @@ void chat(char *buf, struct user_t *user)
      {
 	if(strncasecmp(chatstring, "!setpass ", 9) == 0)
 	  {
+	     char newpass[MAX_ADMIN_PASS_LEN+1];
 	     temp = strchr(chatstring, ' ') + 1;
-	     
-	     /* Using path here and tempstr a few lines down might be a bad idea. */	   
-	     strncpy(path,temp,MAX_FDP_LEN); 
-	     
+
+	     strncpy(newpass,temp,MAX_ADMIN_PASS_LEN);
+	     newpass[MAX_ADMIN_PASS_LEN] = '\0';
+
 	     if(remove_reg_user(user->nick, user) > 0)
-	       {		
-		  encrypt_pass(path);
-		  
+	       {
+		  encrypt_pass(newpass);
+
 		  if (user->type == OP_ADMIN)
-		    snprintf(tempstr, MAX_HOST_LEN, "%s %s %d", user->nick, path, 2);
+		    snprintf(tempstr, MAX_HOST_LEN, "%s %s %d", user->nick, newpass, 2);
 		  else if (user->type == OP)
-		    snprintf(tempstr, MAX_HOST_LEN, "%s %s %d", user->nick, path, 1);
+		    snprintf(tempstr, MAX_HOST_LEN, "%s %s %d", user->nick, newpass, 1);
 		  else
-		    snprintf(tempstr, MAX_HOST_LEN, "%s %s %d", user->nick, path, 0);
-		  
+		    snprintf(tempstr, MAX_HOST_LEN, "%s %s %d", user->nick, newpass, 0);
+
 		  snprintf(path, MAX_FDP_LEN, "%s/%s", config_dir, REG_FILE);
-		  
+
 		  if (add_line_to_file(tempstr, path) > 0)
 		    {
 		       uprintf(user, "<Hub-Security> Password changed|");
@@ -468,7 +469,7 @@ void chat(char *buf, struct user_t *user)
 	       }
 	     else
 	       logprintf(1, "Error - Failed to change password for user %s\n", user->nick);
-	     
+
 	     return;
 	  }
      }
@@ -2106,7 +2107,7 @@ void quit_program(void)
 }
 
 /* Constant-time string comparison to prevent timing attacks */
-static int secure_strcmp(const char *a, const char *b)
+int secure_strcmp(const char *a, const char *b)
 {
    size_t alen = strlen(a);
    size_t blen = strlen(b);
@@ -2125,7 +2126,7 @@ int check_admin_pass(char *buf, struct user_t *user)
    char command[21];
    char pass[MAX_ADMIN_PASS_LEN+1];
 
-   sscanf(buf, "%20s %50[^|]|", command, pass);
+   sscanf(buf, "%20s %120[^|]|", command, pass);
 
    if(secure_strcmp(pass, admin_pass) == 0)
      {
@@ -2514,6 +2515,30 @@ void set_var(char *org_buf, struct user_t *user)
 	   int slen = cut_string(buf, '|');
 	   if(slen < 0) slen = 0;
 	   if(slen > MAX_HOST_LEN) slen = MAX_HOST_LEN;
+
+	   /* Validate path: reject directory traversal and absolute paths */
+	   {
+	      char tmppath[MAX_HOST_LEN+1];
+	      strncpy(tmppath, buf, slen);
+	      tmppath[slen] = '\0';
+	      if(strstr(tmppath, "..") != NULL)
+		{
+		   if(user->type == ADMIN)
+		     uprintf(user, "\r\nError: log_file path must not contain '..'\r\n");
+		   else if(user->type == OP_ADMIN)
+		     uprintf(user, "<Hub-Security> Error: log_file path must not contain '..'|");
+		   return;
+		}
+	      if(tmppath[0] == '/')
+		{
+		   if(user->type == ADMIN)
+		     uprintf(user, "\r\nError: log_file must be a relative path\r\n");
+		   else if(user->type == OP_ADMIN)
+		     uprintf(user, "<Hub-Security> Error: log_file must be a relative path|");
+		   return;
+		}
+	   }
+
 	   strncpy(log_file_path, buf, slen);
 	   log_file_path[slen] = '\0';
 	}

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -1743,7 +1743,7 @@ int check_pass(char *buf, struct user_t *user)
 		  else
 		    tmp = this_passwd;
 
-		  if(tmp != NULL && strcmp(tmp,reg_passwd) == 0)
+		  if(tmp != NULL && secure_strcmp(tmp,reg_passwd) == 0)
 		    {
 		       /* Users password is correct */
 		       int user_type_code;
@@ -1832,7 +1832,7 @@ int check_pass(char *buf, struct user_t *user)
  
    if(strlen(default_pass) > 0)
      {
-        if(strcmp(this_passwd,default_pass) == 0)
+        if(secure_strcmp(this_passwd,default_pass) == 0)
           {
             /* User is regular but default pass required */
             return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -88,7 +88,7 @@ struct user_t **human_hash_table = NULL;
 struct sock_t *human_sock_list = NULL;
 unsigned int listening_port = 0;
 unsigned int admin_port = 0;
-BYTE   admin_localhost = 0;
+BYTE   admin_localhost = 1;
 int    admin_listening_socket = 0;
 int    listening_socket = 0;
 int    listening_unx_socket = 0;
@@ -166,7 +166,7 @@ int set_default_vars(void)
    reverse_dns = 0;
    redirect_host[0] = '\0';
    admin_port = 0xD1C0;  /* Easy to remember :) */
-   admin_localhost = 0;
+   admin_localhost = 1;
    searchcheck_exclude_internal = 1;
    searchcheck_exclude_all = 0;
    kick_bantime = 5;

--- a/src/main.h
+++ b/src/main.h
@@ -268,3 +268,4 @@ void   remove_human_from_hash(char *nick);
 struct user_t* get_human_user(char *nick);
 void   remove_human_user(struct user_t *user);
 void   encrypt_pass(char* password);
+int    secure_strcmp(const char *a, const char *b);


### PR DESCRIPTION
## Summary
- Use constant-time `secure_strcmp()` for password verification (prevents timing side-channel)
- Validate `log_file` path to reject path traversal (`..` and absolute paths)
- Fix buffer overflow in `!setpass` with dedicated `newpass` buffer
- Fix `sscanf` width specifier (`%50` → `%120`) to match `MAX_NICK_LEN`
- Default `admin_localhost` to 1 (require explicit override for remote admin access)

## Test plan
- [x] All 118 integration tests pass
- [x] Docker build succeeds
- [ ] Manual test: verify `!setpass` with long passwords doesn't crash
- [ ] Manual test: verify `log_file = ../../../etc/shadow` is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)