### PR TITLE
Fix version string and persist TLS config

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(configure.in)
-AM_INIT_AUTOMAKE(opendchub, 0.9.0)
+AM_INIT_AUTOMAKE(opendchub, 0.12.0)
 AM_CONFIG_HEADER(config.h)
 AM_SANITY_CHECK
 AC_DEFINE(_GNU_SOURCE)

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -2083,7 +2083,15 @@ int write_config_file(void)
    fprintf(fp, "max_desc_len = %d\n\n", max_desc_len);
    
    fprintf(fp, "crypt_enable = %d\n\n", crypt_enable);
-   
+
+#ifdef HAVE_SSL
+   fprintf(fp, "tls_port = %u\n\n", tls_port);
+
+   fprintf(fp, "tls_cert_file = \"%s\"\n\n", tls_cert_file);
+
+   fprintf(fp, "tls_key_file = \"%s\"\n\n", tls_key_file);
+#endif
+
    set_lock(fd, F_UNLCK);
    
    while(((erret = fclose(fp)) != 0) && (errno == EINTR))

--- a/test/run.sh
+++ b/test/run.sh
@@ -37,6 +37,25 @@ else
     fail "SSL/TLS support NOT compiled in"
 fi
 
+# Test 2c: Version string matches expected
+if grep -q 'VERSION "0.12.0"' /build/opendchub/config.h; then
+    pass "Version string is 0.12.0"
+else
+    fail "Version string mismatch (expected 0.12.0)"
+fi
+
+# Test 2d: TLS config persistence in write_config_file
+if grep -q "tls_port" /build/opendchub/src/fileio.c && grep -q "tls_cert_file" /build/opendchub/src/fileio.c; then
+    # Check that fprintf for tls settings exists (write path, not just read path)
+    if grep -q 'fprintf.*tls_port' /build/opendchub/src/fileio.c; then
+        pass "TLS config written in write_config_file()"
+    else
+        fail "TLS config NOT written in write_config_file()"
+    fi
+else
+    fail "TLS config variables missing from fileio.c"
+fi
+
 echo ""
 echo "========================================"
 echo "=== Source Code Fix Verification     ==="


### PR DESCRIPTION
## Summary
- **Version mismatch**: configure.in still said `0.9.0` — binary self-reported wrong version despite .deb tagged as 0.11.x. Bumped to `0.12.0`.
- **TLS config lost on rewrite**: `write_config_file()` never wrote `tls_port`, `tls_cert_file`, or `tls_key_file`. Any config rewrite (e.g. `$SetVar`) silently stripped TLS settings, breaking TLS on next restart.

## Test plan
- [x] Docker build succeeds (57 tests, 0 failures)
- [x] Version test: `config.h` contains `VERSION "0.12.0"`
- [x] TLS persistence test: `fprintf` for `tls_port` exists in `write_config_file()`
- [ ] Manual: configure TLS, run hub, trigger config write, verify TLS settings survive restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)